### PR TITLE
Additional age requirement options

### DIFF
--- a/frontend/app/about/page.tsx
+++ b/frontend/app/about/page.tsx
@@ -21,9 +21,8 @@ export default function Page() {
                 About Us
             </h1>
 
-            <Paper elevation={8}
+            <Paper elevation={0}
                    sx={{
-                       height: "100vh",
                        backgroundColor: "transparent",
                        color: "white",
                        paddingX: "3.25rem",

--- a/frontend/app/events/dashboard/page.tsx
+++ b/frontend/app/events/dashboard/page.tsx
@@ -694,6 +694,25 @@ export default function Page() {
                                             )}
                                             />
 
+                                <Controller name="ageRequirement"
+                                            control={control}
+                                            render={({ field }) =>  (
+                                                <FormControl>
+                                                    <FormLabel sx={{ color: "#aaa", "&.Mui-focused": { color: "#aaa"}} }>Age Requirement</FormLabel>
+                                                    <RadioGroup
+                                                        defaultValue="21+"
+                                                        {...field}
+                                                        value={field.value}
+                                                        onChange={(e) => field.onChange(e.target.value)}
+                                                    >
+                                                        <FormControlLabel value="21+" control={ <Radio /> } label="21+" />
+                                                        <FormControlLabel value="18+" control={ <Radio /> } label="18+" />
+                                                        <FormControlLabel value="None" control={ <Radio /> } label="None" />
+                                                    </RadioGroup>
+                                                </FormControl>
+                                            )}
+                                />
+
                             </Stack>
                         </Grid>
 
@@ -841,19 +860,6 @@ export default function Page() {
                                                 )}
                                     />
                                 </LocalizationProvider>
-
-                                <FormControl>
-                                    <FormLabel sx={{ color: "#aaa", "&.Mui-focused": { color: "#aaa"}} }>Age Requirement</FormLabel>
-                                    <RadioGroup
-                                        defaultValue="21+"
-                                        {...register("ageRequirement")}
-                                    >
-                                        <FormControlLabel value="21+"
-                                                          control={ <Radio /> }
-                                                          label="21+" />
-                                        <FormControlLabel value="18+" control={<Radio />} label="18+" />
-                                    </RadioGroup>
-                                </FormControl>
 
                                 <CustomButton
                                     variant="contained"

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,44 +1,45 @@
-import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import type {Metadata} from "next";
+import {Geist, Geist_Mono} from "next/font/google";
 import "./ui/globals.css";
 import Header from "@/app/components/header";
 import {Box} from "@mui/material";
+import {AppRouterCacheProvider} from "@mui/material-nextjs/v13-appRouter";
 
 
 const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
+    variable: "--font-geist-sans",
+    subsets: ["latin"],
 });
 
 const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+    variable: "--font-geist-mono",
+    subsets: ["latin"],
 });
 
 export const metadata: Metadata = {
-  title: "Red Room",
-  description: "",
+    title: "Red Room",
+    description: "",
 };
 
 export default function RootLayout({
-  children,
-}: Readonly<{
-  children: React.ReactNode;
+                                       children,
+                                   }: Readonly<{
+    children: React.ReactNode;
 }>) {
-  return (
-    <html lang="en" className="bg-black">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        <Box sx={{
-            minHeight: "100vh",
-            color: "white",
-            backgroundImage: "linear-gradient(#000000 10%, #1a0000 20%, #4a0000 45%, #8b0000 100%)",
-        }}>
-            <Header />
-            {children}
-        </Box>
-      </body>
-    </html>
-  );
+    return (
+        <html lang="en" className="bg-black">
+        <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <AppRouterCacheProvider>
+            <Box sx={{
+                minHeight: "100vh",
+                color: "white",
+                backgroundImage: "linear-gradient(#000000 10%, #1a0000 20%, #4a0000 45%, #8b0000 100%)",
+            }}>
+                <Header/>
+                {children}
+            </Box>
+        </AppRouterCacheProvider>
+        </body>
+        </html>
+    );
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
+    "@mui/material-nextjs": "^9.1.1",
     "@mui/x-date-pickers": "^9.5.0",
     "dayjs": "^1.11.21",
     "lucide-react": "^1.7.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@mui/material':
         specifier: ^9.0.0
         version: 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@mui/material-nextjs':
+        specifier: ^9.1.1
+        version: 9.1.1(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@mui/x-date-pickers':
         specifier: ^9.5.0
         version: 9.5.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@mui/system@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(dayjs@1.11.21)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -468,6 +471,24 @@ packages:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/material-nextjs@9.1.1':
+    resolution: {integrity: sha512-OUM0a2GvzKXkkFxKBjs6O36pXv5/vhmgET+k6XNaKR+gG2B4wU1rlGuUkynddbvuVqgdF5ZjElIZAf2W7TRMZA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/cache': ^11.11.0
+      '@emotion/react': ^11.11.4
+      '@emotion/server': ^11.11.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/cache':
+        optional: true
+      '@emotion/server':
+        optional: true
       '@types/react':
         optional: true
 
@@ -3014,6 +3035,16 @@ snapshots:
       '@mui/material': 9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
     optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@mui/material-nextjs@9.1.1(@emotion/cache@11.14.0)(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(next@16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@emotion/react': 11.14.0(@types/react@19.2.14)(react@19.2.3)
+      next: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@emotion/cache': 11.14.0
       '@types/react': 19.2.14
 
   '@mui/material@9.0.0(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':


### PR DESCRIPTION
Added a "none" option for the age requirement field when creating an event through the event dashboard.

Also fixed a bug where the other radio buttons for the age requirement were not actually passing data. Only the 21+ button was working. I wrapped the whole FormControl into a Controller just like other components and it seemed to fix the issue.

Fixed a hydration issue that was being caused by not having material-nextjs installed. emotions was injecting its own "styles" attribute into the layout. adding this package and wrapping the app in a AppRouterCacheProvider solved this issue.

Fixed the about us page as well. Background was not fully extending the page as the Paper component had a height. Removed the height and elevation.